### PR TITLE
apim v2 with gpt-4-turbo add and model versions

### DIFF
--- a/src/aoai_helpers.py
+++ b/src/aoai_helpers.py
@@ -30,19 +30,25 @@ def translate_engine_to_model(engine):
     tiktoken.encoding_for_model for token tracking.
     '''
     try:
-        engine_model_dict = {"gpt-35-turbo": "gpt-3.5-turbo",
-                             "gpt-35-turbo-16k": "gpt-3.5-turbo-16k-0613",
-                             "gpt-4": "gpt-4-0613",
-                             "gpt-4-32k": "gpt-4-32k-0613"}
+        engine_model_dict = {"gpt-35-turbo-0301" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-0613" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-1106" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-16k" : "gpt-3.5-turbo-16k-0613",
+							 "gpt-4" : "gpt-4-0613",
+							 "gpt-4-32k" : "gpt-4-32k-0613",
+							 "gpt-4-turbo" : "gpt-4-32k-0613"}
         model = engine_model_dict.get(engine)
         if model is None:
             raise KeyError(f"Engine {engine} not found. Please use one of the following: {list(engine_model_dict.keys())}")
         return model
     except KeyError:
-        engine_model_dict = {"gpt-35-turbo": "gpt-3.5-turbo",
-                             "gpt-35-turbo-16k": "gpt-3.5-turbo-16k-0613",
-                             "gpt-4": "gpt-4-0613",
-                             "gpt-4-32k": "gpt-4-32k-0613"}
+        engine_model_dict = {"gpt-35-turbo-0301" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-0613" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-1106" : "gpt-3.5-turbo",
+							 "gpt-35-turbo-16k" : "gpt-3.5-turbo-16k-0613",
+							 "gpt-4" : "gpt-4-0613",
+							 "gpt-4-32k" : "gpt-4-32k-0613",
+							 "gpt-4-turbo" : "gpt-4-32k-0613"}
         raise KeyError(f"Engine {engine} not found. Please use one of the following: {list(engine_model_dict.keys())}")
 
 def num_tokens_from_messages(messages, model):
@@ -85,9 +91,55 @@ def num_tokens_from_messages(messages, model):
     num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
     return num_tokens
 
+def env_to_st_session_state(setting_name, session_name, default_value):  
+    """  
+    Function to generate st.session_state variables from environment variables.  
+    """  
+    if session_name not in st.session_state:  
+        if os.environ.get(setting_name) is not None:
+            st.session_state[session_name] = os.environ.get(setting_name)
+        else:
+            st.session_state[session_name] = default_value
+
+def load_settings(reload_api_settings=True):
+    # These set the default values for the sidebar optoins and are used in aoai_streamlit_app.py
+    # This is what values return to when reset is clicked
+    env_to_st_session_state('ST_ENGINE', 'engine', 'gpt-35-turbo-16k')
+    env_to_st_session_state('ST_TEMPERATURE', 'temperature', 0.5)
+    env_to_st_session_state('ST_MAX_TOKENS', 'maxtokens', 4000)
+    env_to_st_session_state('ST_TOP_P', 'topp', 0.90)
+    env_to_st_session_state('ST_FREQUENCY_PENALTY', 'frequencypenalty', 0.0)
+    env_to_st_session_state('ST_PRESENCE_PENALTY', 'presencepenalty', 0.0)
+
+    # These are the default values for the API settings
+    # only loaded if reload_api_settings = True
+    if reload_api_settings:
+        # Load in the API settings if requested
+        env_to_st_session_state('AOAI_API_TYPE', 'apitype', 'azure')
+        env_to_st_session_state('AOAI_API_VERSION', 'apiversion', '2023-05-15')
+        env_to_st_session_state('APIM_KEY', 'apikey', '')
+        env_to_st_session_state('APIM_ENDPOINT', 'apiendpoint', '')
+
+def toggle_settings():
+    st.session_state['show_settings'] = not st.session_state['show_settings']
+
+def save_session_state():
+    st.session_state.apitype = st.session_state.apitype 
+    st.session_state.apiversion = st.session_state.apiversion 
+    st.session_state.apikey = st.session_state.apikey 
+    st.session_state.apiendpoint = st.session_state.apiendpoint
+    st.session_state.engine = st.session_state.modelkey
+    st.session_state.temperature = st.session_state.tempkey 
+    st.session_state.maxtokens = st.session_state.tokenskey 
+    st.session_state.topp = st.session_state.top_pkey 
+    st.session_state.frequencypenalty = st.session_state.frequency_penaltykey
+    st.session_state.presencepenalty = st.session_state.presence_penaltykey
+    st.session_state.system = st.session_state.txtSystem 
+    st.session_state.messages[0]['content'] = st.session_state.system
+
 # Define a dictionary for  use with st.sidebar when loaded into aoai_streamlit_app.py
 model_params = {  
-    "gpt-35-turbo": {
+    "gpt-35-turbo-0301": {
         "tokens_min": 10,
         "tokens_max": 4000,
         "tokens_step": 10,
@@ -117,7 +169,69 @@ model_params = {
         "presence_penalty_step": 0.01,
         "presence_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating any token that has appeared in the text at all so far. 
         This increases the likelihood of introducing new topics in a response.''',
-        },  
+        },
+    "gpt-35-turbo-0613": {
+        "tokens_min": 10,
+        "tokens_max": 4000,
+        "tokens_step": 10,
+        "tokens_help": '''Set a limit on the number of tokens per model response. 
+        The API supports a maximum of 4000 tokens shared between the prompt (including system message, examples, message history, and user query) and the model's response. 
+        One token is roughly 4 characters for typical English text.''',
+        "temp_min": 0.00,
+        "temp_max": 2.00,
+        "temp_step": 0.01,
+        "temp_help": '''Controls randomness. Lowering the temperature means that the model will produce more repetitive and deterministic responses.
+         Increasing the temperature will result in more unexpected or creative responses. Try adjusting temperature or Top P but not both.''',
+        "top_p_min": 0.00,
+        "top_p_max": 1.00,
+        "top_p_step": 0.01,
+        "top_p_help": '''Similar to temperature, this controls randomness but uses a different method, called nucleus sampling where
+        the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 
+        10% probability mass are considered. Lowering Top P will narrow the model’s token selection to likelier tokens. 
+        Increasing Top P will let the model choose from tokens with both high and low likelihood. 
+        Try adjusting temperature or Top P but not both.''',
+        "frequency_penalty_min": -2.00,
+        "frequency_penalty_max": 2.00,
+        "frequency_penalty_step": 0.01,
+        "frequency_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating a token proportionally based on how often it has appeared in the text so far. 
+        This decreases the likelihood of repeating the exact same text in a response..''',
+        "presence_penalty_min": -2.00,
+        "presence_penalty_max": 2.00,
+        "presence_penalty_step": 0.01,
+        "presence_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating any token that has appeared in the text at all so far. 
+        This increases the likelihood of introducing new topics in a response.''',
+        },
+    "gpt-35-turbo-1106": {
+        "tokens_min": 10,
+        "tokens_max": 16000,
+        "tokens_step": 10,
+        "tokens_help": '''Set a limit on the number of tokens per model response. 
+        The API supports a maximum of 4000 tokens shared between the prompt (including system message, examples, message history, and user query) and the model's response. 
+        One token is roughly 4 characters for typical English text.''',
+        "temp_min": 0.00,
+        "temp_max": 2.00,
+        "temp_step": 0.01,
+        "temp_help": '''Controls randomness. Lowering the temperature means that the model will produce more repetitive and deterministic responses.
+         Increasing the temperature will result in more unexpected or creative responses. Try adjusting temperature or Top P but not both.''',
+        "top_p_min": 0.00,
+        "top_p_max": 1.00,
+        "top_p_step": 0.01,
+        "top_p_help": '''Similar to temperature, this controls randomness but uses a different method, called nucleus sampling where
+        the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 
+        10% probability mass are considered. Lowering Top P will narrow the model’s token selection to likelier tokens. 
+        Increasing Top P will let the model choose from tokens with both high and low likelihood. 
+        Try adjusting temperature or Top P but not both.''',
+        "frequency_penalty_min": -2.00,
+        "frequency_penalty_max": 2.00,
+        "frequency_penalty_step": 0.01,
+        "frequency_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating a token proportionally based on how often it has appeared in the text so far. 
+        This decreases the likelihood of repeating the exact same text in a response..''',
+        "presence_penalty_min": -2.00,
+        "presence_penalty_max": 2.00,
+        "presence_penalty_step": 0.01,
+        "presence_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating any token that has appeared in the text at all so far. 
+        This increases the likelihood of introducing new topics in a response.''',
+        },
     "gpt-35-turbo-16k": {
         "tokens_min": 10,
         "tokens_max": 16000,
@@ -210,52 +324,37 @@ model_params = {
         "presence_penalty_step": 0.01,
         "presence_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating any token that has appeared in the text at all so far. 
         This increases the likelihood of introducing new topics in a response.''',
+        },
+    "gpt-4-turbo": {
+        "tokens_min": 10,
+        "tokens_max": 4096,
+        "tokens_step": 10,
+        "tokens_help": '''Set a limit on the number of tokens per model response. 
+        The API supports a maximum of 4,096 tokens for it's output. HOWEVER, it has a 128,000 token context window, so large amounts of text may be submitted but it will
+        still be limited to the 4,096 max token output in a single response. You can ask it to continue to keep providing output if it cuts off mid-sentence.''',
+        "temp_min": 0.00,
+        "temp_max": 2.00,
+        "temp_step": 0.01,
+        "temp_help": '''Controls randomness. Lowering the temperature means that the model will produce more repetitive and deterministic responses.
+         Increasing the temperature will result in more unexpected or creative responses. Try adjusting temperature or Top P but not both.''',
+        "top_p_min": 0.00,
+        "top_p_max": 1.00,
+        "top_p_step": 0.01,
+        "top_p_help": '''Similar to temperature, this controls randomness but uses a different method, called nucleus sampling where
+        the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 
+        10% probability mass are considered. Lowering Top P will narrow the model’s token selection to likelier tokens. 
+        Increasing Top P will let the model choose from tokens with both high and low likelihood. 
+        Try adjusting temperature or Top P but not both.''',
+        "frequency_penalty_min": -2.00,
+        "frequency_penalty_max": 2.00,
+        "frequency_penalty_step": 0.01,
+        "frequency_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating a token proportionally based on how often it has appeared in the text so far. 
+        This decreases the likelihood of repeating the exact same text in a response..''',
+        "presence_penalty_min": -2.00,
+        "presence_penalty_max": 2.00,
+        "presence_penalty_step": 0.01,
+        "presence_penalty_help": '''Number between -2.0 and 2.0. Reduce the chance of repeating any token that has appeared in the text at all so far. 
+        This increases the likelihood of introducing new topics in a response.''',
         },  
     # Add more models here...  
     }
-
-def env_to_st_session_state(setting_name, session_name, default_value):  
-    """  
-    Function to generate st.session_state variables from environment variables.  
-    """  
-    if session_name not in st.session_state:  
-        if os.environ.get(setting_name) is not None:
-            st.session_state[session_name] = os.environ.get(setting_name)
-        else:
-            st.session_state[session_name] = default_value
-
-def load_settings(reload_api_settings=True):
-    # These set the default values for the sidebar optoins and are used in aoai_streamlit_app.py
-    # This is what values return to when reset is clicked
-    env_to_st_session_state('ST_ENGINE', 'engine', 'gpt-35-turbo-16k')
-    env_to_st_session_state('ST_TEMPERATURE', 'temperature', 0.5)
-    env_to_st_session_state('ST_MAX_TOKENS', 'maxtokens', 4000)
-    env_to_st_session_state('ST_TOP_P', 'topp', 0.90)
-    env_to_st_session_state('ST_FREQUENCY_PENALTY', 'frequencypenalty', 0.0)
-    env_to_st_session_state('ST_PRESENCE_PENALTY', 'presencepenalty', 0.0)
-
-    # These are the default values for the API settings
-    # only loaded if reload_api_settings = True
-    if reload_api_settings:
-        # Load in the API settings if requested
-        env_to_st_session_state('AOAI_API_TYPE', 'apitype', 'azure')
-        env_to_st_session_state('AOAI_API_VERSION', 'apiversion', '2023-05-15')
-        env_to_st_session_state('APIM_KEY', 'apikey', '')
-        env_to_st_session_state('APIM_ENDPOINT', 'apiendpoint', '')
-
-def toggle_settings():
-    st.session_state['show_settings'] = not st.session_state['show_settings']
-
-def save_session_state():
-    st.session_state.apitype = st.session_state.apitype 
-    st.session_state.apiversion = st.session_state.apiversion 
-    st.session_state.apikey = st.session_state.apikey 
-    st.session_state.apiendpoint = st.session_state.apiendpoint
-    st.session_state.engine = st.session_state.modelkey
-    st.session_state.temperature = st.session_state.tempkey 
-    st.session_state.maxtokens = st.session_state.tokenskey 
-    st.session_state.topp = st.session_state.top_pkey 
-    st.session_state.frequencypenalty = st.session_state.frequency_penaltykey
-    st.session_state.presencepenalty = st.session_state.presence_penaltykey
-    st.session_state.system = st.session_state.txtSystem 
-    st.session_state.messages[0]['content'] = st.session_state.system

--- a/src/aoai_streamlit_app.py
+++ b/src/aoai_streamlit_app.py
@@ -43,9 +43,16 @@ with st.sidebar.title("Model Parameters", anchor="top", help='''The model parame
 
         # Create a dictionary containing the available models for each completion type 
         # ###UPDATE 07/12/2023 first round will only accomodate the Chat models until gpt-35-turbo-instruct is released
+        # ###UPDATE 01/30/2024 - added new models, still keeping just chat for now
         available_models = {  
-            "Chat": ["gpt-4", "gpt-4-32k", "gpt-35-turbo", "gpt-35-turbo-16k"],  
-            #"Completion": ["text-davinci-003"],  
+            "Chat": ["gpt-35-turbo-0301",
+                     "gpt-35-turbo-0613",
+                     "gpt-35-turbo-1106",
+                     "gpt-35-turbo-16k",
+                     "gpt-4",
+                     "gpt-4-32k",
+                     "gpt-4-turbo"], # ["gpt-4", "gpt-4-32k", "gpt-35-turbo", "gpt-35-turbo-16k"], 
+            #"Completion": ["text-davinci-003", "gpt-35-turbo-instruct"],  
             #"Embedding": ["text-embedding-ada-002"]  
         }
 
@@ -165,7 +172,8 @@ with chat_container:
                                                             stop=None,
                                                             stream=True):
 
-                full_response += response.choices[0].delta.get("content", "")
+                if response.choices and len(response.choices) > 0:
+                    full_response += response.choices[0].delta.get("content", "")
                 message_placeholder.markdown(full_response + "▌")
             message_placeholder.markdown(full_response)
         st.session_state.messages.append({"role": "assistant", "content": full_response})

--- a/src/test.ipynb
+++ b/src/test.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import openai\n",
+    "from dotenv import load_dotenv  \n",
+    "\n",
+    "load_dotenv()  \n",
+    "\n",
+    "openai.api_type = \"azure\"  \n",
+    "openai.api_key = os.environ['APIM_KEY']  \n",
+    "openai.api_base = os.environ['APIM_ENDPOINT']  \n",
+    "openai.api_version = os.environ['AOAI_API_VERSION']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://apimanagementaoai.azure-api.net/\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openai.api_base)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<OpenAIObject chat.completion id=chatcmpl-8E2dIHvhk37B2GHStuCFicjIXqOJN at 0x1b0df0bb050> JSON: {\n",
+       "  \"id\": \"chatcmpl-8E2dIHvhk37B2GHStuCFicjIXqOJN\",\n",
+       "  \"object\": \"chat.completion\",\n",
+       "  \"created\": 1698357404,\n",
+       "  \"model\": \"gpt-4\",\n",
+       "  \"choices\": [\n",
+       "    {\n",
+       "      \"index\": 0,\n",
+       "      \"finish_reason\": \"stop\",\n",
+       "      \"message\": {\n",
+       "        \"role\": \"assistant\",\n",
+       "        \"content\": \"Why don't APIM developers play hide and seek?\\n\\nBecause good luck hiding when they always expose your endpoints!\"\n",
+       "      }\n",
+       "    }\n",
+       "  ],\n",
+       "  \"usage\": {\n",
+       "    \"prompt_tokens\": 29,\n",
+       "    \"completion_tokens\": 22,\n",
+       "    \"total_tokens\": 51\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "engine = \"gpt-4\"\n",
+    "messages = [{\"role\":\"system\",\"content\":\"You are an AI assistant that helps people find information.\"},\n",
+    "            {\"role\":\"user\",\"content\":\"Tell me a joke about APIM\"}]\n",
+    "temperature = 0.9\n",
+    "max_tokens = 800\n",
+    "top_p = 0.9\n",
+    "stream = False\n",
+    "\n",
+    "openai.ChatCompletion.create(\n",
+    "            engine=engine,\n",
+    "            messages=messages,\n",
+    "            temperature=temperature,\n",
+    "            max_tokens=max_tokens,\n",
+    "            top_p=top_p,\n",
+    "            stream=stream\n",
+    "        )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "aoai-streamlit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Added apim v2 endpoint and keys with backend based on models and separated by versions. I added gpt-4-turbo and then separated the gpt-35-turbo model versions out. 
I will look to updated streamlit versions and migrated from openai sdk 0.28 to 1.x